### PR TITLE
Make `SVPressKeys` work system-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+* `SVPressKeys` now emits the keyboard shortcut system-wide instead of only in the Xcode process.
+    * This can be used to have a custom passthrough for hot keys (e.g. <kbd>⌥\`</kbd> to open iTerm) by adding this to your `init.vim`:
+    ```viml
+    if exists('g:shadowvim')
+        map <A-`> <Cmd>SVPressKeys <LT>A-`><CR>
+    endif
+    ```
 
 ## [0.1.1]
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ The following commands are available in your bindings when Neovim is run by Shad
 
 Neovim is in read-only mode, so `:w` won't do anything. Use the usual <kbd>⌘S</kbd> to save your files.
 
+### Custom passthrough for hot keys
+
+All keyboard shortcuts that are not using the <kbd>⌘</kbd> modifier are sent to Neovim. This means that if you have a global hot key (e.g. <kbd>⌥\`</kbd> to open iTerm), it won't work when Xcode is focused.
+
+As a workaround, you can add a custom mapping to your `init.vim` to retrigger your hot key globally.
+
+```viml
+map <A-`> <Cmd>SVPressKeys <LT>A-`><CR>
+```
+
 ### Navigation with <kbd>C-o</kbd> and <kbd>C-i</kbd>
 
 Cross-buffers navigation is not yet supported with ShadowVim. Therefore, it is recommended to override the <kbd>C-o</kbd> and <kbd>C-i</kbd> mappings to use Xcode's navigation instead.

--- a/Sources/Mediator/MediatorContainer.swift
+++ b/Sources/Mediator/MediatorContainer.swift
@@ -66,10 +66,7 @@ public final class MediatorContainer {
                 events: nvim.events,
                 logger: logger?.domain("nvim-buffers")
             ),
-            eventSource: try EventSource(
-                pid: app.processIdentifier,
-                keyResolver: keyResolver
-            ),
+            eventSource: try EventSource(keyResolver: keyResolver),
             logger: logger?.domain("app"),
             bufferMediatorFactory: bufferMediator,
             enableKeysPassthrough: enableKeysPassthrough,

--- a/Sources/Toolkit/Input/EventSource.swift
+++ b/Sources/Toolkit/Input/EventSource.swift
@@ -22,19 +22,16 @@ public enum EventSourceError: Error {
     case failedToCreateSource
 }
 
-/// An event source allows to post events (e.g. key combos) to the application
-/// with a given `pid`.
+/// An event source allows to post events (e.g. key combos) to the system.
 public final class EventSource {
-    private let pid: pid_t
     private let source: CGEventSource
     private let keyResolver: CGKeyResolver
 
-    public init(pid: pid_t, keyResolver: CGKeyResolver) throws {
+    public init(keyResolver: CGKeyResolver) throws {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             throw EventSourceError.failedToCreateSource
         }
 
-        self.pid = pid
         self.source = source
         self.keyResolver = keyResolver
     }
@@ -48,12 +45,12 @@ public final class EventSource {
             return false
         }
 
-        DispatchQueue.main.async { [self] in
+        DispatchQueue.main.async {
             let flags = kc.modifiers.cgFlags
             downEvent.flags = flags
             upEvent.flags = flags
-            downEvent.postToPid(pid)
-            upEvent.postToPid(pid)
+            downEvent.post(tap: .cgSessionEventTap)
+            upEvent.post(tap: .cgSessionEventTap)
         }
 
         return true


### PR DESCRIPTION
### Changed

* `SVPressKeys` now emits the keyboard shortcut system-wide instead of only in the Xcode process.
    * This can be used to have a custom passthrough for hot keys (e.g. <kbd>⌥\`</kbd> to open iTerm) by adding this to your `init.vim`:
    ```viml
    if exists('g:shadowvim')
        map <A-`> <Cmd>SVPressKeys <LT>A-`><CR>
    endif
    ```

---

* Fix #33 