### PR TITLE
Perform mouse clicks with `SVPress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* Use `SVPress` to trigger click events from Neovim bindings.
+    ```viml
+    " Show the Quick Help pop-up for the symbol at the caret location (<kbd>⌥ + Left Click</kbd>).
+    nmap K <Cmd>SVPress <LT>M-LeftMouse><CR>
+
+    " Perform a right click at the caret location.
+    nmap gr <Cmd>SVPress <LT>RightMouse><CR>
+    ```
+
 ### Changed
 
-* `SVPressKeys` now emits the keyboard shortcut system-wide instead of only in the Xcode process.
+* `SVPressKeys` was renamed to `SVPress`.
+* `SVPress` now emits the keyboard shortcut system-wide instead of only in the Xcode process.
     * This can be used to have a custom passthrough for hot keys (e.g. <kbd>⌥\`</kbd> to open iTerm) by adding this to your `init.vim`:
     ```viml
     if exists('g:shadowvim')

--- a/README.md
+++ b/README.md
@@ -68,14 +68,17 @@ To conditionally activate plugins, `vim-plug` has a
 
 Only <kbd>⌃</kbd>/<kbd>C-</kbd>-based keyboard shortcuts can be customized in Neovim. <kbd>⌘</kbd>-based hotkeys are handled directly by Xcode.
 
-The `SVPressKeys` user command triggers a keyboard shortcut in Xcode. This is convenient to bind Neovim commands to Xcode features, such as:
+The `SVPress` user command triggers a keyboard shortcut or mouse click in Xcode. This is convenient to bind Neovim commands to Xcode features, such as:
 
 ```viml
-" Jump to Definition (⌃⌘J)
-nmap gd <Cmd>SVPressKeys <LT>C-D-j><CR>
+" Jump to Definition (⌃⌘J).
+nmap gd <Cmd>SVPress <LT>C-D-j><CR>
+
+" Show the Quick Help pop-up for the symbol at the caret location (<kbd>⌥ + Left Click</kbd>).
+nmap K <Cmd>SVPress <LT>M-LeftMouse><CR>
 ```
 
-:warning: The first `<` needs to be escaped as `<LT>` when calling `SVPressKeys` from a key binding.
+:warning: The first `<` needs to be escaped as `<LT>` when calling `SVPress` from a key binding.
 
 | Modifier | macOS        | Nvim                           |
 |----------|--------------|--------------------------------|
@@ -99,7 +102,7 @@ ShadowVim adds a new menu bar icon (🅽) with a couple of useful features which
 
 The following commands are available in your bindings when Neovim is run by ShadowVim.
 
-* `SVPressKeys` triggers a keyboard shortcut in Xcode. The syntax is the same as Neovim's key bindings, e.g. `SVPressKeys <D-s>` to save the current file.
+* `SVPress` triggers a keyboard shortcut or mouse click in Xcode. The syntax is the same as Neovim's key bindings, e.g. `SVPress <D-s>` to save the current file. Mouse clicks are performed at the current caret location.
 * `SVEnableKeysPassthrough` switches on the Keys Passthrough mode, which lets Xcode handle key events until you press <kbd>⎋</kbd>.
 * `SVReset` kills Neovim and resets the synchronization. This might be useful if you get stuck.
 * `SVSynchronizeUI` requests Xcode to reset the current file to the state of the Neovim buffer. You should not need to call this manually.
@@ -118,7 +121,7 @@ All keyboard shortcuts that are not using the <kbd>⌘</kbd> modifier are sent t
 As a workaround, you can add a custom mapping to your `init.vim` to retrigger your hot key globally.
 
 ```viml
-map <A-`> <Cmd>SVPressKeys <LT>A-`><CR>
+map <A-`> <Cmd>SVPress <LT>A-`><CR>
 ```
 
 ### Navigation with <kbd>C-o</kbd> and <kbd>C-i</kbd>
@@ -126,18 +129,18 @@ map <A-`> <Cmd>SVPressKeys <LT>A-`><CR>
 Cross-buffers navigation is not yet supported with ShadowVim. Therefore, it is recommended to override the <kbd>C-o</kbd> and <kbd>C-i</kbd> mappings to use Xcode's navigation instead.
 
 ```viml
-nmap <C-o> <Cmd>SVPressKeys <LT>C-D-Left><CR>
-nmap <C-i> <Cmd>SVPressKeys <LT>C-D-Right><CR>
+nmap <C-o> <Cmd>SVPress <LT>C-D-Left><CR>
+nmap <C-i> <Cmd>SVPress <LT>C-D-Right><CR>
 ```
 
 Unfortunately, this won't work in read-only source editors. As a workaround, you can rebind **Go back** to <kbd>⌃O</kbd> and **Go forward** to <kbd>⌃I</kbd> in Xcode's **Key Bindings** preferences, then in Neovim:
 
 ```viml
-nmap <C-o> <Cmd>SVPressKeys <LT>C-o><CR>
-nmap <C-i> <Cmd>SVPressKeys <LT>C-i><CR>
+nmap <C-o> <Cmd>SVPress <LT>C-o><CR>
+nmap <C-i> <Cmd>SVPress <LT>C-i><CR>
 ```
 
-As `SVPressKeys` is not recursive, this will perform the native Xcode navigation.
+As `SVPress` is not recursive, this will perform the native Xcode navigation.
 
 ### Triggering Xcode's completion
 
@@ -154,32 +157,44 @@ nmap gp /<LT>#.\{-}#><CR>gn
 nmap cap /<LT>#.\{-}#><CR>cgn
 ```
 
+### Mouse clicks
+
+Here are some useful bindings simulating mouse clicks.
+
+```viml
+" Show the Quick Help pop-up for the symbol at the caret location (<kbd>⌥ + Left Click</kbd>).
+nmap K <Cmd>SVPress <LT>M-LeftMouse><CR>
+
+" Perform a right click at the caret location.
+nmap gr <Cmd>SVPress <LT>RightMouse><CR>
+```
+
 ### Window management
 
 Use the following bindings to manage Xcode's source editor with the usual <kbd>C-w</kbd>-based keyboard shortcuts.
 
 ```viml
 " Split vertically.
-map <C-w>v <Cmd>SVPressKeys <LT>C-D-t><CR>
+map <C-w>v <Cmd>SVPress <LT>C-D-t><CR>
 " Split horizontally.
-map <C-w>s <Cmd>SVPressKeys <LT>C-M-D-t><CR>
+map <C-w>s <Cmd>SVPress <LT>C-M-D-t><CR>
 
 " Close the focused editor.
 " Note: Xcode 14 doesn't focus the previous one... As a workaround, ⌃C is triggered to focus the first one.
-map <C-w>c <Cmd>SVPressKeys <LT>C-S-D-w><CR><Cmd>SVPressKeys <LT>C-`><CR>
+map <C-w>c <Cmd>SVPress <LT>C-S-D-w><CR><Cmd>SVPress <LT>C-`><CR>
 " Close all other source editors.
-map <C-w>o <Cmd>SVPressKeys <LT>C-S-M-D-w><CR>
+map <C-w>o <Cmd>SVPress <LT>C-S-M-D-w><CR>
 
 " Focus the editor on the left.
-map <C-w>h <Cmd>SVPressKeys <LT>D-j><CR><Cmd>SVPressKeys h<CR><Cmd>SVPressKeys <LT>CR><CR>
+map <C-w>h <Cmd>SVPress <LT>D-j><CR><Cmd>SVPress h<CR><Cmd>SVPress <LT>CR><CR>
 " Focus the editor below.
-map <C-w>j <Cmd>SVPressKeys <LT>D-j><CR><Cmd>SVPressKeys j<CR><Cmd>SVPressKeys <LT>CR><CR>
+map <C-w>j <Cmd>SVPress <LT>D-j><CR><Cmd>SVPress j<CR><Cmd>SVPress <LT>CR><CR>
 " Focus the editor above.
-map <C-w>k <Cmd>SVPressKeys <LT>D-j><CR><Cmd>SVPressKeys k<CR><Cmd>SVPressKeys <LT>CR><CR>
+map <C-w>k <Cmd>SVPress <LT>D-j><CR><Cmd>SVPress k<CR><Cmd>SVPress <LT>CR><CR>
 " Focus the editor on the right.
-map <C-w>l <Cmd>SVPressKeys <LT>D-j><CR><Cmd>SVPressKeys l<CR><Cmd>SVPressKeys <LT>CR><CR>
+map <C-w>l <Cmd>SVPress <LT>D-j><CR><Cmd>SVPress l<CR><Cmd>SVPress <LT>CR><CR>
 " Rotate the source editors.
-map <C-w>w <Cmd>SVPressKeys <LT>C-`><CR>
+map <C-w>w <Cmd>SVPress <LT>C-`><CR>
 ```
 
 ### Folds
@@ -187,10 +202,10 @@ map <C-w>w <Cmd>SVPressKeys <LT>C-`><CR>
 Xcode's folding capabilities are limited, but you get the basics with these bindings:
 
 ```viml
-nmap zc <Cmd>SVPressKeys <LT>M-D-Left><CR>
-nmap zo <Cmd>SVPressKeys <LT>M-D-Right><CR>
-nmap zM <Cmd>SVPressKeys <LT>M-S-D-Left><CR>
-nmap zR <Cmd>SVPressKeys <LT>M-S-D-Right><CR>
+nmap zc <Cmd>SVPress <LT>M-D-Left><CR>
+nmap zo <Cmd>SVPress <LT>M-D-Right><CR>
+nmap zM <Cmd>SVPress <LT>M-S-D-Left><CR>
+nmap zR <Cmd>SVPress <LT>M-S-D-Right><CR>
 ```
 
 ### Opening third-party applications

--- a/Sources/Mediator/Buffer/BufferMediator.swift
+++ b/Sources/Mediator/Buffer/BufferMediator.swift
@@ -103,6 +103,20 @@ public final class BufferMediator {
             .store(in: &subscriptions)
     }
 
+    /// Returns the screen coordinates to the current UI cursor position.
+    ///
+    /// When a range is selected, returns the center point.
+    func uiCursorLocation() throws -> CGPoint? {
+        guard
+            let element = uiElement,
+            let selectedRange: CFRange = try element.get(.selectedTextRange),
+            let bounds: CGRect = try element.get(.boundsForRange, with: selectedRange)
+        else {
+            return nil
+        }
+        return CGPoint(x: bounds.midX, y: bounds.midY)
+    }
+
     func synchronize(source: BufferState.Host) {
         DispatchQueue.main.async {
             self.on(.didRequestRefresh(source: .nvim))

--- a/Sources/Nvim/Toolkit/Key+Nvim.swift
+++ b/Sources/Nvim/Toolkit/Key+Nvim.swift
@@ -245,6 +245,9 @@ private let lookupTo: [Notation: Toolkit.Key] = [
     "kdivide": .keypadDivide,
     "kenter": .keypadEnter,
     "kequal": .keypadEquals,
+
+    "leftmouse": .leftMouse,
+    "rightmouse": .rightMouse,
 ]
 
 private let lookupFrom: [Toolkit.Key: (Notation, bracketed: Bool)] = [
@@ -344,4 +347,7 @@ private let lookupFrom: [Toolkit.Key: (Notation, bracketed: Bool)] = [
     .keypadDivide: ("kDivide", bracketed: true),
     .keypadEnter: ("kEnter", bracketed: true),
     .keypadEquals: ("kEqual", bracketed: true),
+
+    .leftMouse: ("LeftMouse", bracketed: true),
+    .rightMouse: ("RightMouse", bracketed: true),
 ]

--- a/Sources/ShadowVim/ShadowVim.swift
+++ b/Sources/ShadowVim/ShadowVim.swift
@@ -55,7 +55,6 @@ class ShadowVim: ObservableObject {
     func didLaunch() {
         addToLoginItems()
         start()
-        try! NvimProcess.apiInfo(logger: logger)
     }
 
     private func addToLoginItems() {

--- a/Sources/Toolkit/Input/EventSource.swift
+++ b/Sources/Toolkit/Input/EventSource.swift
@@ -36,11 +36,54 @@ public final class EventSource {
         self.keyResolver = keyResolver
     }
 
+    /// Posts a keyboard event for the given key combo.
+    @discardableResult
     public func press(_ kc: KeyCombo) -> Bool {
         guard
+            !kc.key.isMouseButton,
             let code = keyResolver.code(for: kc.key),
             let downEvent = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true),
             let upEvent = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: false)
+        else {
+            return false
+        }
+
+        DispatchQueue.main.async {
+            let flags = kc.modifiers.cgFlags
+            downEvent.flags = flags
+            upEvent.flags = flags
+            downEvent.post(tap: .cgSessionEventTap)
+            upEvent.post(tap: .cgSessionEventTap)
+        }
+
+        return true
+    }
+
+    /// Posts a mouse click event at the given point.
+    ///
+    /// Only the keys `leftMouse` and `rightMouse` are supported in the key
+    /// combo.
+    @discardableResult
+    public func click(_ kc: KeyCombo, at point: CGPoint) -> Bool {
+        let typeDown: CGEventType
+        let typeUp: CGEventType
+        let button: CGMouseButton
+        switch kc.key {
+        case .leftMouse:
+            button = .left
+            typeDown = .leftMouseDown
+            typeUp = .leftMouseUp
+        case .rightMouse:
+            button = .right
+            typeDown = .rightMouseDown
+            typeUp = .rightMouseUp
+        default:
+            return false
+        }
+
+        guard
+            let downEvent = CGEvent(mouseEventSource: source, mouseType: typeDown, mouseCursorPosition: point, mouseButton: button),
+            let upEvent = CGEvent(mouseEventSource: source, mouseType: typeUp, mouseCursorPosition: point, mouseButton: button)
         else {
             return false
         }

--- a/Sources/Toolkit/Input/Key.swift
+++ b/Sources/Toolkit/Input/Key.swift
@@ -170,6 +170,19 @@ public enum Key: Hashable {
     // Keycodes for ISO keyboard only
     case section
 
+    // Mouse buttons
+    case leftMouse
+    case rightMouse
+
+    public var isMouseButton: Bool {
+        switch self {
+        case .leftMouse, .rightMouse:
+            return true
+        default:
+            return false
+        }
+    }
+
     public var isNonPrintableCharacter: Bool {
         Key.nonPrintableKeys.contains(self)
     }
@@ -179,6 +192,6 @@ public enum Key: Hashable {
         .upArrow, .downArrow, .leftArrow, .rightArrow,
         .pageUp, .pageDown, .home, .end, .help,
         .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12,
-        .keypadClear, .keypadEnter,
+        .keypadClear, .keypadEnter, .leftMouse, .rightMouse,
     ]
 }

--- a/Tests/NvimTests/Toolkit/Key+NvimTests.swift
+++ b/Tests/NvimTests/Toolkit/Key+NvimTests.swift
@@ -117,6 +117,8 @@ final class KeyNvimTests: XCTestCase {
         XCTAssertEqual(KeyCombo(.keypadDivide).nvimNotation, "<kDivide>")
         XCTAssertEqual(KeyCombo(.keypadEnter).nvimNotation, "<kEnter>")
         XCTAssertEqual(KeyCombo(.keypadEquals).nvimNotation, "<kEqual>")
+        XCTAssertEqual(KeyCombo(.leftMouse).nvimNotation, "<LeftMouse>")
+        XCTAssertEqual(KeyCombo(.rightMouse).nvimNotation, "<RightMouse>")
     }
 
     func testNotationOfCharacterWithModifiers() {
@@ -233,6 +235,8 @@ final class KeyNvimTests: XCTestCase {
         XCTAssertEqual(KeyCombo(nvimNotation: "<kDivide>"), KeyCombo(.keypadDivide))
         XCTAssertEqual(KeyCombo(nvimNotation: "<kEnter>"), KeyCombo(.keypadEnter))
         XCTAssertEqual(KeyCombo(nvimNotation: "<kEqual>"), KeyCombo(.keypadEquals))
+        XCTAssertEqual(KeyCombo(nvimNotation: "<LeftMouse>"), KeyCombo(.leftMouse))
+        XCTAssertEqual(KeyCombo(nvimNotation: "<RightMouse>"), KeyCombo(.rightMouse))
     }
 
     func testKeyComboFromNotationOfCharacterWithModifiers() {


### PR DESCRIPTION
### Added

* Use `SVPress` to trigger click events from Neovim bindings.
    ```viml
    " Show the Quick Help pop-up for the symbol at the caret location (<kbd>⌥ + Left Click</kbd>).
    nmap K <Cmd>SVPress <LT>M-LeftMouse><CR>
    " Perform a right click at the caret location.
    nmap gr <Cmd>SVPress <LT>RightMouse><CR>
    ```