### PR TITLE
Improve handling of paste shortcut (⌘V)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+* The system paste shortcut (<kbd>⌘V</kbd>) is now overridden and handled by Neovim to improve performances and the undo history.
+
 
 ## [0.1.1]
 

--- a/Sources/Mediator/App/AppMediator.swift
+++ b/Sources/Mediator/App/AppMediator.swift
@@ -263,6 +263,7 @@ public final class AppMediator {
 
     private let cmdZ = KeyCombo(.z, modifiers: .command)
     private let cmdShiftZ = KeyCombo(.z, modifiers: [.command, .shift])
+    private let cmdV = KeyCombo(.v, modifiers: [.command])
 
     private func handle(_ event: KeyEvent, in buffer: NvimBuffer) -> Bool {
         switch event.keyCombo {
@@ -277,6 +278,19 @@ public final class AppMediator {
         case cmdShiftZ:
             nvim.vim?.atomic(in: buffer) { vim in
                 vim.cmd.redo()
+            }
+            .discardResult()
+            .forwardErrorToDelegate(of: self)
+            .run()
+
+        case cmdV:
+            // We override the system paste behavior to improve performance and
+            // nvim's undo history.
+            guard let text = NSPasteboard.get() else {
+                break
+            }
+            nvim.vim?.atomic(in: buffer) { vim in
+                vim.api.paste(text)
             }
             .discardResult()
             .forwardErrorToDelegate(of: self)

--- a/Sources/Nvim/Vim/API.swift
+++ b/Sources/Nvim/Vim/API.swift
@@ -196,6 +196,17 @@ public class API {
         .discardResult()
     }
 
+    /// Pastes at cursor, in any mode.
+    /// https://neovim.io/doc/user/api.html#nvim_paste()
+    public func paste(_ data: String) -> Async<Void, NvimError> {
+        request("nvim_paste", with: [
+            data,
+            false, // crlf
+            -1 // phase
+        ])
+        .discardResult()
+    }
+
     public func winGetWidth(_ window: WindowHandle = 0) -> Async<Int, NvimError> {
         request("nvim_win_get_width", with: Value.window(window))
             .checkedUnpacking { $0.intValue }

--- a/Sources/Nvim/Vim/API.swift
+++ b/Sources/Nvim/Vim/API.swift
@@ -202,7 +202,7 @@ public class API {
         request("nvim_paste", with: [
             data,
             false, // crlf
-            -1 // phase
+            -1, // phase
         ])
         .discardResult()
     }

--- a/Sources/Toolkit/Extensions/AppKit/NSPasteboard.swift
+++ b/Sources/Toolkit/Extensions/AppKit/NSPasteboard.swift
@@ -19,7 +19,6 @@ import AppKit
 import Foundation
 
 public extension NSPasteboard {
-
     static func get() -> String? {
         guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else {
             return nil

--- a/Sources/Toolkit/Extensions/AppKit/NSPasteboard.swift
+++ b/Sources/Toolkit/Extensions/AppKit/NSPasteboard.swift
@@ -19,6 +19,14 @@ import AppKit
 import Foundation
 
 public extension NSPasteboard {
+
+    static func get() -> String? {
+        guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
     static func set(_ contents: String) {
         let pasteboard = NSPasteboard.general
         pasteboard.declareTypes([.string], owner: nil)


### PR DESCRIPTION
### Changed

* The system paste shortcut (<kbd>⌘V</kbd>) is now overridden and handled by Neovim to improve performances and the undo history.