### PR TITLE
Add `SVSetInputUI` and `SVSetInputNvim` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 * Support for Visual and Select modes feedback.
     * Block-wise selection (<kbd>C-v</kbd>) is displayed as character-wise because of a limitation with the Xcode accessibility APIs.
+* Open a Neovim terminal TUI for the embedded instance (requires Neovim 0.9).
+    * This is useful to solve blocking prompts in Neovim, for instance.
+    * Activate from the status menu, or manually with:
+        ```sh
+        nvim --server /tmp/shadowvim.pipe --remote-ui
+        ```
 * Use `SVPress` to trigger click events from Neovim bindings.
     ```viml
     " Show the Quick Help pop-up for the symbol at the caret location (<kbd>⌥ + Left Click</kbd>).
@@ -16,12 +22,12 @@ All notable changes to this project will be documented in this file.
     " Perform a right click at the caret location.
     nmap gR <Cmd>SVPress <LT>RightMouse><CR>
     ```
-* Open a Neovim terminal TUI for the embedded instance (requires Neovim 0.9).
-    * This is useful to solve blocking prompts in Neovim, for instance.
-    * Activate from the status menu, or manually with:
-        ```sh
-        nvim --server /tmp/shadowvim.pipe --remote-ui
-        ```
+* Use `SVSetInputUI` to let Xcode handle all key events.
+* Use `SVSetInputNvim` to forward key events to Neovim, even in Insert mode.
+
+### Deprecated
+
+* `SVEnableKeysPassthrough` is deprecated in favor of the new `SVSetInputUI` command.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Take a look at the [Tips and tricks](#tips-and-tricks) section for a collection 
 
 ShadowVim adds a new menu bar icon (🅽) with a couple of useful features which can also be triggered with global hotkeys:
 
-* **Keys Passthrough** (<kbd>⌃⌥⌘.</kbd>) lets Xcode handle key events until you press <kbd>⎋</kbd>. You **must** use this when renaming a symbol with Xcode's refactor tools, otherwise the buffer will get messed up.
 * **Reset ShadowVim** (<kbd>⌃⌥⌘⎋</kbd>) kills Neovim and resets the synchronization. This might be useful if you get stuck.
 
 ### Neovim user commands
@@ -107,8 +106,9 @@ ShadowVim adds a new menu bar icon (🅽) with a couple of useful features which
 The following commands are available in your bindings when Neovim is run by ShadowVim.
 
 * `SVPress` triggers a keyboard shortcut or mouse click in Xcode. The syntax is the same as Neovim's key bindings, e.g. `SVPress <D-s>` to save the current file. Mouse clicks are performed at the current caret location.
-* `SVEnableKeysPassthrough` switches on the Keys Passthrough mode, which lets Xcode handle key events until you press <kbd>⎋</kbd>.
 * `SVReset` kills Neovim and resets the synchronization. This might be useful if you get stuck.
+* `SVSetInputUI` lets Xcode handle all key events. Press <kbd>Esc</kbd> to cancel.
+* `SVSetInputNvim` forwards key events to Neovim, even in Insert mode. Press <kbd>Esc</kbd> to cancel.
 * `SVSynchronizeUI` requests Xcode to reset the current file to the state of the Neovim buffer. You should not need to call this manually.
 * `SVSynchronizeNvim` requests Neovim to reset the current buffer to the state of the Xcode file. You should not need to call this manually.
 

--- a/Sources/Mediator/App/AppMediator.swift
+++ b/Sources/Mediator/App/AppMediator.swift
@@ -140,12 +140,6 @@ public final class AppMediator {
         delegate?.appMediatorDidStop(self)
     }
 
-    public func didToggleKeysPassthrough(enabled: Bool) {
-        for (_, buffer) in bufferMediators {
-            buffer.didToggleKeysPassthrough(enabled: enabled)
-        }
-    }
-
     private func on(_ event: AppState.Event) {
         precondition(Thread.isMainThread)
         state.on(event, logger: logger)

--- a/Sources/Mediator/App/AppMediator.swift
+++ b/Sources/Mediator/App/AppMediator.swift
@@ -364,6 +364,12 @@ extension AppMediator: NvimControllerDelegate {
         synchronizeFocusedBuffer(source: source)
     }
 
+    func nvimController(_ nvimController: NvimController, setInput host: BufferHost) {
+        for (_, buffer) in bufferMediators {
+            buffer.setInput(host: host)
+        }
+    }
+
     func nvimController(_ nvimController: NvimController, press notation: Notation) -> Bool {
         press(notation: notation)
     }

--- a/Sources/Mediator/Buffer/BufferMediator.swift
+++ b/Sources/Mediator/Buffer/BufferMediator.swift
@@ -108,6 +108,12 @@ public final class BufferMediator {
         }
     }
 
+    func setInput(host: BufferHost) {
+        DispatchQueue.main.async {
+            self.on(.didRequestSetInput(host: host))
+        }
+    }
+
     func didToggleKeysPassthrough(enabled: Bool) {
         DispatchQueue.main.async {
             self.on(.didToggleKeysPassthrough(enabled: enabled))

--- a/Sources/Mediator/Buffer/BufferMediator.swift
+++ b/Sources/Mediator/Buffer/BufferMediator.swift
@@ -114,12 +114,6 @@ public final class BufferMediator {
         }
     }
 
-    func didToggleKeysPassthrough(enabled: Bool) {
-        DispatchQueue.main.async {
-            self.on(.didToggleKeysPassthrough(enabled: enabled))
-        }
-    }
-
     func didFocus(element: AXUIElement) {
         precondition(Thread.isMainThread)
 

--- a/Sources/Mediator/Buffer/BufferState.swift
+++ b/Sources/Mediator/Buffer/BufferState.swift
@@ -79,9 +79,6 @@ enum BufferEvent: Equatable {
     /// When `nil`, the event happened outside the bounds of the UI buffer.
     case uiDidReceiveMouseEvent(MouseEvent.Kind, bufferPoint: CGPoint?)
 
-    /// The keys passthrough was toggled.
-    case didToggleKeysPassthrough(enabled: Bool)
-
     /// An error occurred.
     case didFail(EquatableError)
 }
@@ -245,8 +242,6 @@ extension BufferEvent: LogPayloadConvertible {
             return "uiDidReceiveKeyEvent"
         case .uiDidReceiveMouseEvent:
             return "uiDidReceiveMouseEvent"
-        case .didToggleKeysPassthrough:
-            return "didToggleKeysPassthrough"
         case .didFail:
             return "didFail"
         }
@@ -276,8 +271,6 @@ extension BufferEvent: LogPayloadConvertible {
             } else {
                 return "\(kind) outside buffer"
             }
-        case let .didToggleKeysPassthrough(enabled: enabled):
-            return "\(enabled)"
         case let .didFail(error):
             return error.error.localizedDescription
         default:
@@ -309,8 +302,6 @@ extension BufferEvent: LogPayloadConvertible {
             return [.name: name, "keyCombo": kc.description, "character": character]
         case let .uiDidReceiveMouseEvent(kind, bufferPoint: bufferPoint):
             return [.name: name, "kind": String(reflecting: kind), "bufferPoint": bufferPoint]
-        case let .didToggleKeysPassthrough(enabled: enabled):
-            return [.name: name, "enabled": enabled]
         case let .didFail(error):
             return [.name: name, "error": error]
         }

--- a/Sources/Mediator/Buffer/BufferState.swift
+++ b/Sources/Mediator/Buffer/BufferState.swift
@@ -43,6 +43,9 @@ enum BufferEvent: Equatable {
     /// `source` host for the source of truth of the content.
     case didRequestRefresh(source: BufferHost)
 
+    /// The user requested to change the `host` handling key input.
+    case didRequestSetInput(host: BufferHost)
+
     /// The Nvim buffer lines changed.
     case nvimLinesDidChange(BufLinesEvent)
 
@@ -222,6 +225,8 @@ extension BufferEvent: LogPayloadConvertible {
             return "didTimeout"
         case .didRequestRefresh:
             return "userDidRequestRefresh"
+        case .didRequestSetInput:
+            return "didRequestSetInput"
         case .nvimLinesDidChange:
             return "nvimLinesDidChange"
         case .nvimModeDidChange:
@@ -253,6 +258,8 @@ extension BufferEvent: LogPayloadConvertible {
             return "\(id)"
         case let .didRequestRefresh(source: source):
             return source.rawValue
+        case let .didRequestSetInput(host: host):
+            return host.rawValue
         case let .nvimLinesDidChange(event):
             return "\(event.firstLine)-\(event.lastLine) (\(event.lineData.count) lines)"
         case let .nvimModeDidChange(mode):
@@ -284,6 +291,8 @@ extension BufferEvent: LogPayloadConvertible {
             return [.name: name]
         case let .didRequestRefresh(source: source):
             return [.name: name, "source": source.rawValue]
+        case let .didRequestSetInput(host: host):
+            return [.name: name, "host": host.rawValue]
         case let .nvimLinesDidChange(event):
             return [.name: name, "event": event]
         case let .nvimModeDidChange(mode):

--- a/Sources/Mediator/Buffer/CooperativeBufferState.swift
+++ b/Sources/Mediator/Buffer/CooperativeBufferState.swift
@@ -32,7 +32,8 @@ struct CooperativeBufferState: BufferState {
     /// Indicates whether the input host should not change automatically with
     /// the Nvim mode.
     ///
-    /// This is set when the user calls explicitly the `SVSetInput` command.
+    /// This is set when the user calls explicitly the `SVSetInputUI` and
+    /// `SVSetInputNvim` commands.
     private var isInputLocked: Bool
 
     /// Which buffer host sent line changes last.

--- a/Sources/Mediator/Buffer/NvimDrivenBufferState.swift
+++ b/Sources/Mediator/Buffer/NvimDrivenBufferState.swift
@@ -286,6 +286,9 @@ struct NvimDrivenBufferState: BufferState {
 
         case let .didFail(error):
             perform(.alert(error))
+
+        default:
+            break
         }
 
         // Syntactic sugar.

--- a/Sources/Mediator/Buffer/NvimDrivenBufferState.swift
+++ b/Sources/Mediator/Buffer/NvimDrivenBufferState.swift
@@ -34,9 +34,6 @@ struct NvimDrivenBufferState: BufferState {
     /// State of the UI buffer.
     private(set) var ui: UIState
 
-    /// Indicates whether the keys passthrough is switched on.
-    private(set) var isKeysPassthroughEnabled: Bool
-
     /// Indicates whether the left mouse button is pressed.
     private(set) var isLeftMouseButtonDown: Bool
 
@@ -47,14 +44,12 @@ struct NvimDrivenBufferState: BufferState {
         token: EditionToken = .free,
         nvim: NvimState = NvimState(),
         ui: UIState = UIState(),
-        isKeysPassthroughEnabled: Bool = false,
         isLeftMouseButtonDown: Bool = false,
         isSelecting: Bool = false
     ) {
         self.token = token
         self.nvim = nvim
         self.ui = ui
-        self.isKeysPassthroughEnabled = isKeysPassthroughEnabled
         self.isLeftMouseButtonDown = isLeftMouseButtonDown
         self.isSelecting = isSelecting
     }
@@ -271,19 +266,6 @@ struct NvimDrivenBufferState: BufferState {
             // Other mouse events are ignored.
             break
 
-        case let .didToggleKeysPassthrough(enabled: enabled):
-            isKeysPassthroughEnabled = enabled
-
-            if enabled {
-                perform(.nvimStopVisual)
-            }
-
-            let selection = ui.selection.adjusted(
-                to: enabled ? .insert : nvim.mode,
-                lines: ui.lines
-            )
-            perform(.uiUpdateSelections([selection]))
-
         case let .didFail(error):
             perform(.alert(error))
 
@@ -357,12 +339,8 @@ struct NvimDrivenBufferState: BufferState {
         func adjustUISelection(to mode: Mode) {
             precondition(token == .acquired(owner: .ui))
 
-            let adjustedSelection = {
-                guard !isKeysPassthroughEnabled else {
-                    return ui.selection
-                }
-                return ui.selection.adjusted(to: mode, lines: ui.lines)
-            }()
+            let adjustedSelection =
+                ui.selection.adjusted(to: mode, lines: ui.lines)
 
             if ui.selection != adjustedSelection {
                 ui.selection = adjustedSelection

--- a/Sources/Mediator/Buffer/UISelection.swift
+++ b/Sources/Mediator/Buffer/UISelection.swift
@@ -38,6 +38,10 @@ struct UISelection: Equatable {
         start.line == end.line && start.column == end.column
     }
 
+    func collapsed() -> UISelection {
+        UISelection(start: start, end: start)
+    }
+
     func copy(
         startLine: LineIndex? = nil,
         startColumn: ColumnIndex? = nil,

--- a/Sources/Mediator/MainMediator.swift
+++ b/Sources/Mediator/MainMediator.swift
@@ -103,12 +103,6 @@ public final class MainMediator {
         return mediator.handle(event)
     }
 
-    public func didToggleKeysPassthrough(enabled: Bool) {
-        for (_, app) in apps {
-            app.didToggleKeysPassthrough(enabled: enabled)
-        }
-    }
-
     private func didActivateApp(_ app: NSRunningApplication) {
         _ = mediator(of: app)
     }

--- a/Sources/Mediator/MediatorContainer.swift
+++ b/Sources/Mediator/MediatorContainer.swift
@@ -25,19 +25,16 @@ import Toolkit
 public final class MediatorContainer {
     private let keyResolver: CGKeyResolver
     private let logger: Logger?
-    private let enableKeysPassthrough: () -> Void
     private let resetShadowVim: () -> Void
     private let nvimContainer: NvimContainer
 
     public init(
         keyResolver: CGKeyResolver,
         logger: Logger?,
-        enableKeysPassthrough: @escaping () -> Void,
         resetShadowVim: @escaping () -> Void
     ) {
         self.keyResolver = keyResolver
         self.logger = logger?.domain("mediator")
-        self.enableKeysPassthrough = enableKeysPassthrough
         self.resetShadowVim = resetShadowVim
 
         nvimContainer = NvimContainer(logger: logger)
@@ -87,7 +84,6 @@ public final class MediatorContainer {
                 logger: logger?.domain("buffers")
             ),
             logger: logger,
-            enableKeysPassthrough: enableKeysPassthrough,
             resetShadowVim: resetShadowVim
         )
     }

--- a/Sources/Mediator/Nvim/NvimController.swift
+++ b/Sources/Mediator/Nvim/NvimController.swift
@@ -101,20 +101,17 @@ final class NvimController {
     private let buffers: NvimBuffers
     private let logger: Logger?
     private var subscriptions: Set<AnyCancellable> = []
-    private let enableKeysPassthrough: () -> Void
     private let resetShadowVim: () -> Void
 
     init(
         nvim: Nvim,
         buffers: NvimBuffers,
         logger: Logger?,
-        enableKeysPassthrough: @escaping () -> Void,
         resetShadowVim: @escaping () -> Void
     ) {
         self.nvim = nvim
         self.buffers = buffers
         self.logger = logger
-        self.enableKeysPassthrough = enableKeysPassthrough
         self.resetShadowVim = resetShadowVim
 
         nvim.delegate = self
@@ -142,19 +139,18 @@ final class NvimController {
 
     private func setupUserCommands() -> Async<Void, NvimError> {
         withAsyncGroup { group in
-            nvim.add(command: "SVSetInput", args: .one) { [weak self] params in
-                guard let self, let delegate = self.delegate else {
-                    return .nil
+            nvim.add(command: "SVSetInputUI") { [weak self] _ in
+                if let self {
+                    self.delegate?.nvimController(self, setInput: .ui)
                 }
-                guard
-                    params.count == 1,
-                    case let .string(arg) = params[0],
-                    let host = BufferHost(rawValue: arg.lowercased())
-                else {
-                    throw NvimControllerError.invalidCommandArgument(command: "SVSetInput", message: "Expected a single argument: ui or nvim")
-                }
+                return .nil
+            }
+            .add(to: group)
 
-                delegate.nvimController(self, setInput: host)
+            nvim.add(command: "SVSetInputNvim") { [weak self] _ in
+                if let self {
+                    self.delegate?.nvimController(self, setInput: .nvim)
+                }
                 return .nil
             }
             .add(to: group)
@@ -175,15 +171,6 @@ final class NvimController {
             }
             .add(to: group)
 
-            nvim.add(command: "SVPressKeys", args: .one) { [weak self] _ in
-                if let self = self {
-                    let error = NvimControllerError.deprecatedCommand(name: "SVPressKeys", replacement: "Use 'SVPress' in your Neovim configuration instead.")
-                    self.delegate?.nvimController(self, didFailWithError: error)
-                }
-                return .bool(false)
-            }
-            .add(to: group)
-
             nvim.add(command: "SVPress", args: .one) { [weak self] params in
                 guard
                     let self,
@@ -197,15 +184,27 @@ final class NvimController {
             }
             .add(to: group)
 
-            nvim.add(command: "SVEnableKeysPassthrough") { [weak self] _ in
-                self?.enableKeysPassthrough()
+            nvim.add(command: "SVReset") { [weak self] _ in
+                self?.resetShadowVim()
                 return .nil
             }
             .add(to: group)
 
-            nvim.add(command: "SVReset") { [weak self] _ in
-                self?.resetShadowVim()
+            nvim.add(command: "SVEnableKeysPassthrough") { [weak self] _ in
+                if let self = self {
+                    let error = NvimControllerError.deprecatedCommand(name: "SVEnableKeysPassthrough", replacement: "Use 'SVSetInputUI' in your Neovim configuration instead.")
+                    self.delegate?.nvimController(self, didFailWithError: error)
+                }
                 return .nil
+            }
+            .add(to: group)
+
+            nvim.add(command: "SVPressKeys", args: .one) { [weak self] _ in
+                if let self = self {
+                    let error = NvimControllerError.deprecatedCommand(name: "SVPressKeys", replacement: "Use 'SVPress' in your Neovim configuration instead.")
+                    self.delegate?.nvimController(self, didFailWithError: error)
+                }
+                return .bool(false)
             }
             .add(to: group)
         }

--- a/Sources/ShadowVim/Container.swift
+++ b/Sources/ShadowVim/Container.swift
@@ -57,7 +57,6 @@ final class Container {
         mediator = MediatorContainer(
             keyResolver: keyResolver,
             logger: logger,
-            enableKeysPassthrough: { [unowned self] in enableKeysPassthrough() },
             resetShadowVim: { [unowned self] in resetShadowVim() }
         )
 
@@ -68,12 +67,6 @@ final class Container {
             setVerboseLogger: { logger.set(NSLoggerLogger()) },
             mediatorFactory: mediator.mainMediator
         )
-    }
-
-    private func enableKeysPassthrough() {
-        DispatchQueue.main.async { [self] in
-            shadowVim.setKeysPassthrough(true)
-        }
     }
 
     private func resetShadowVim() {

--- a/Sources/ShadowVim/ShadowVim.swift
+++ b/Sources/ShadowVim/ShadowVim.swift
@@ -25,8 +25,6 @@ import ServiceManagement
 import Toolkit
 
 class ShadowVim: ObservableObject {
-    @Published var keysPassthrough: Bool = false
-
     private var mediator: MainMediator?
     private let eventTap = EventTap()
 
@@ -72,15 +70,6 @@ class ShadowVim: ObservableObject {
 
     func willTerminate() {
         stop()
-    }
-
-    func setKeysPassthrough(_ enabled: Bool) {
-        keysPassthrough = enabled
-        mediator?.didToggleKeysPassthrough(enabled: enabled)
-    }
-
-    func toggleKeysPassthrough() {
-        setKeysPassthrough(!keysPassthrough)
     }
 
     private func start() {
@@ -229,9 +218,6 @@ extension ShadowVim: EventTapDelegate {
                 case .escape:
                     reset()
                     return nil
-                case .period:
-                    toggleKeysPassthrough()
-                    return nil
                 case .slash:
                     setVerboseLogger()
                     return nil
@@ -239,14 +225,9 @@ extension ShadowVim: EventTapDelegate {
                     break
                 }
             }
-
-            if keysPassthrough, keyCombo == KeyCombo(.escape) {
-                setKeysPassthrough(false)
-            }
         }
 
         guard
-            !keysPassthrough,
             let mediator = mediator,
             mediator.handle(inputEvent)
         else {

--- a/Sources/ShadowVim/ShadowVimApp.swift
+++ b/Sources/ShadowVim/ShadowVimApp.swift
@@ -46,8 +46,6 @@ struct ShadowVimApp: SwiftUI.App {
             }
 
         MenuBarExtra("ShadowVim", systemImage: "n.square.fill") {
-            KeysPassthroughButton(shadowVim: shadowVim)
-
             if Debug.isDebugging {
                 Button("Verbose logging") { shadowVim.setVerboseLogger() }
             }
@@ -69,14 +67,5 @@ struct ShadowVimApp: SwiftUI.App {
             Button("Quit ShadowVim") { shadowVim.quit() }
                 .keyboardShortcut("q")
         }
-    }
-}
-
-struct KeysPassthroughButton: View {
-    @ObservedObject var shadowVim: ShadowVim
-
-    var body: some View {
-        Toggle("Keys Passthrough", isOn: $shadowVim.keysPassthrough)
-            .keyboardShortcut(".", modifiers: [.control, .option, .command])
     }
 }


### PR DESCRIPTION
### Added

* Use `SVSetInputUI` to let Xcode handle all key events.
* Use `SVSetInputNvim` to forward key events to Neovim, even in Insert mode.

### Deprecated

* `SVEnableKeysPassthrough` is deprecated in favor of the new `SVSetInputUI` command.