### PR TITLE
Improve EOF normal UI selection

### DIFF
--- a/Sources/Mediator/Buffer/CooperativeBufferState.swift
+++ b/Sources/Mediator/Buffer/CooperativeBufferState.swift
@@ -100,7 +100,7 @@ struct CooperativeBufferState: BufferState {
         }
 
         func uiSelections() -> [UISelection] {
-            .init(mode: mode, cursor: cursorPosition, visual: visualPosition)
+            [UISelection](mode: mode, cursor: cursorPosition, visual: visualPosition)
         }
     }
 


### PR DESCRIPTION
As we use a one-character selection to represent the normal block caret in the UI, this doesn't work when going to the EOF (e.g. with G) if the last line is empty. As a workaround, this will select the newline character in the previous line to show that we're still in Normal mode and not Insert.

See https://github.com/mickael-menu/ShadowVim/discussions/40#discussioncomment-5379352


https://user-images.githubusercontent.com/58686775/232291614-5520a70a-b45a-45e5-8735-1b9f9d6facb7.mov

