### PR TITLE
Fix cursor position with `vim-wordmotion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+* [#50](https://github.com/mickael-menu/ShadowVim/issues/50) Fix issue where the cursor position is not updated when using third-party plugins like `chaoren/vim-wordmotion`.
+
 
 ## [0.2.0]
 

--- a/Sources/Mediator/Buffer/UISelection.swift
+++ b/Sources/Mediator/Buffer/UISelection.swift
@@ -138,7 +138,9 @@ extension Array where Element == UISelection {
     /// selections
     init(mode: Mode, cursor: BufferPosition, visual: BufferPosition) {
         switch mode {
-        case .normal, .operatorPending:
+        case .normal, .operatorPending, .cmdline:
+            // Needs to support .cmdline too, to support custom moves from plugins.
+            // See https://github.com/mickael-menu/ShadowVim/issues/50
             let end = BufferPosition(line: cursor.line, column: cursor.column + 1)
             self = [UISelection(start: UIPosition(cursor), end: UIPosition(end))]
 
@@ -180,7 +182,7 @@ extension Array where Element == UISelection {
             end.column = 0
             self = [UISelection(start: start, end: end)]
 
-        case .cmdline, .hitEnterPrompt, .shell, .terminal:
+        case .hitEnterPrompt, .shell, .terminal:
             self = []
         }
     }

--- a/Sources/Nvim/Nvim.swift
+++ b/Sources/Nvim/Nvim.swift
@@ -145,6 +145,9 @@ public final class Nvim {
             process.standardInput = input
             process.standardOutput = output
             process.loadEnvironment()
+            // To test a specific Nvim configuration, uncomment and add it to
+            // ~/.config.nvim-test
+//            process.environment!["NVIM_APPNAME"] = "nvim-test"
 
             process.terminationHandler = { [self] _ in
                 DispatchQueue.main.async { self.didTerminate() }

--- a/Tests/MediatorTests/Buffer/UISelectionTests.swift
+++ b/Tests/MediatorTests/Buffer/UISelectionTests.swift
@@ -257,20 +257,26 @@ final class UISelectionArrayTests: XCTestCase {
 
     // In Normal mode, only the cursor position is used and a padding is added
     // to form a 1-character block.
-    func testSelectionsForNormalMode() {
-        XCTAssertEqual(
-            [UISelection](
-                mode: .normal,
-                cursor: BufferPosition(line: 2, column: 3),
-                visual: BufferPosition(line: 2, column: 3)
-            ),
-            [
-                UISelection(
-                    start: UIPosition(line: 1, column: 2),
-                    end: UIPosition(line: 1, column: 3)
+    func testSelectionsForNormalModes() {
+        func test(_ mode: Mode) {
+            XCTAssertEqual(
+                [UISelection](
+                    mode: mode,
+                    cursor: BufferPosition(line: 2, column: 3),
+                    visual: BufferPosition(line: 2, column: 3)
                 ),
-            ]
-        )
+                [
+                    UISelection(
+                        start: UIPosition(line: 1, column: 2),
+                        end: UIPosition(line: 1, column: 3)
+                    ),
+                ]
+            )
+        }
+
+        test(.normal)
+        test(.operatorPending)
+        test(.cmdline)
     }
 
     // In Insert or Replace modes, only the cursor position is used for the
@@ -420,7 +426,6 @@ final class UISelectionArrayTests: XCTestCase {
             )
         }
 
-        test(.cmdline)
         test(.hitEnterPrompt)
         test(.shell)
         test(.terminal)


### PR DESCRIPTION
### Fixed

* [#50](https://github.com/mickael-menu/ShadowVim/issues/50) Fix issue where the cursor position is not updated when using third-party plugins like `chaoren/vim-wordmotion`.

---

* Fix #50 

The Nvim mode changed to `cmdline` when triggering `vim-wordmotion` movement, which was not considered when synchronizing the position. This caused the issue.