### PR TITLE
Add a passthrough for Fn-based keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * [#50](https://github.com/mickael-menu/ShadowVim/issues/50) Fix issue where the cursor position is not updated when using third-party plugins like `chaoren/vim-wordmotion`.
+* [#56](https://github.com/mickael-menu/ShadowVim/issues/56) Add a passthrough for Fn-based keyboard shortcuts.
 
 
 ## [0.2.0]

--- a/Sources/Adapters/Sauce/SauceAdapter.swift
+++ b/Sources/Adapters/Sauce/SauceAdapter.swift
@@ -24,14 +24,25 @@ public final class SauceCGKeyResolver: CGKeyResolver {
 
     public func key(for code: CGKeyCode) -> Toolkit.Key? {
         guard let key = Sauce.shared.key(for: Int(code)) else {
-            return nil
+            switch code {
+            case 179:
+                // The 179/fn key is not handled by Sauce
+                return .fn
+            default:
+                return nil
+            }
         }
         return lookupTo[key]
     }
 
     public func code(for key: Toolkit.Key) -> CGKeyCode? {
         guard let key = lookupFrom[key] else {
-            return nil
+            switch key {
+            case .fn:
+                return 179
+            default:
+                return nil
+            }
         }
         return Sauce.shared.keyCode(for: key)
     }

--- a/Sources/Mediator/Buffer/CooperativeBufferState.swift
+++ b/Sources/Mediator/Buffer/CooperativeBufferState.swift
@@ -309,8 +309,14 @@ struct CooperativeBufferState: BufferState {
                 }
 
                 let mods = kc.modifiers
-                // Passthrough for ⌘-based keyboard shortcuts.
-                guard !mods.contains(.command) else {
+                // Passthrough for Fn or ⌘-based keyboard shortcuts.
+                guard
+                    !mods.contains(.command),
+                    !mods.contains(.function),
+                    // Fn key pressed on its own.
+                    // See https://github.com/mickael-menu/ShadowVim/issues/56
+                    kc != KeyCombo(.fn)
+                else {
                     break
                 }
 

--- a/Sources/Nvim/RPC/Value+RPC.swift
+++ b/Sources/Nvim/RPC/Value+RPC.swift
@@ -45,7 +45,7 @@ extension Value {
                 return try .success(.array(a.map { try Value.from($0).get() }))
             case let .map(m):
                 return try .success(.dict(m.reduce(into: [:]) { d, i in
-                    d[try Value.from(i.key).get()] = try Value.from(i.value).get()
+                    try d[Value.from(i.key).get()] = try Value.from(i.value).get()
                 }))
 
             // MessagePack-RPC extensions as defined in `nvim_get_api_info()`

--- a/Sources/Toolkit/Input/CGKeyResolver.swift
+++ b/Sources/Toolkit/Input/CGKeyResolver.swift
@@ -55,6 +55,9 @@ extension InputModifiers {
         if cgFlags.contains(.maskCommand) {
             insert(.command)
         }
+        if cgFlags.contains(.maskSecondaryFn) {
+            insert(.function)
+        }
     }
 
     var cgFlags: CGEventFlags {
@@ -70,6 +73,9 @@ extension InputModifiers {
         }
         if contains(.command) {
             flags.insert(.maskCommand)
+        }
+        if contains(.function) {
+            flags.insert(.maskSecondaryFn)
         }
         return flags
     }

--- a/Sources/Toolkit/Input/InputModifiers.swift
+++ b/Sources/Toolkit/Input/InputModifiers.swift
@@ -20,10 +20,11 @@ import Foundation
 
 public struct InputModifiers: OptionSet, Hashable, CustomStringConvertible {
     public static let none = InputModifiers([])
-    public static let shift = InputModifiers(rawValue: 1 << 3)
-    public static let control = InputModifiers(rawValue: 1 << 0)
-    public static let option = InputModifiers(rawValue: 1 << 1)
-    public static let command = InputModifiers(rawValue: 1 << 2)
+    public static let shift = InputModifiers(rawValue: 1 << 0)
+    public static let control = InputModifiers(rawValue: 1 << 1)
+    public static let option = InputModifiers(rawValue: 1 << 2)
+    public static let command = InputModifiers(rawValue: 1 << 3)
+    public static let function = InputModifiers(rawValue: 1 << 4)
 
     public let rawValue: Int
 
@@ -44,6 +45,9 @@ public struct InputModifiers: OptionSet, Hashable, CustomStringConvertible {
         }
         if contains(.shift) {
             desc += "⇧"
+        }
+        if contains(.function) {
+            desc += "Fn"
         }
         return desc
     }

--- a/Sources/Toolkit/Input/Key.swift
+++ b/Sources/Toolkit/Input/Key.swift
@@ -53,6 +53,9 @@ public enum Key: String, Hashable {
     case end
     case help
 
+    /// Fn key when pressed on its own.
+    case fn
+
     case a
     case b
     case c


### PR DESCRIPTION
### Fixed

* [#56](https://github.com/mickael-menu/ShadowVim/issues/56) Add a passthrough for Fn-based keyboard shortcuts.